### PR TITLE
Add 14B action-conditioned training recipe for 16fps clips

### DIFF
--- a/cosmos_predict2/configs/action_conditioned/defaults/data.py
+++ b/cosmos_predict2/configs/action_conditioned/defaults/data.py
@@ -40,6 +40,7 @@ bridge_train_dataset = L(ActionConditionedDataset)(
     video_size=[480, 640],
     val_start_frame_interval=1,
     mode="train",
+    output_fps=4,
 )
 
 bridge_val_dataset = L(ActionConditionedDataset)(
@@ -54,6 +55,41 @@ bridge_val_dataset = L(ActionConditionedDataset)(
     video_size=[480, 640],
     val_start_frame_interval=1,
     mode="val",
+    output_fps=4,
+)
+
+
+my16fps_base_path = "./datasets/my_16fps_action/"
+my16fps_train_dataset = L(ActionConditionedDataset)(
+    train_annotation_path=os.path.join(my16fps_base_path, "annotation/train"),
+    val_annotation_path=os.path.join(my16fps_base_path, "annotation/val"),
+    test_annotation_path=os.path.join(my16fps_base_path, "annotation/test"),
+    video_path=my16fps_base_path,
+    sequence_interval=1,
+    num_frames=48,
+    cam_ids=[0],
+    accumulate_action=False,
+    video_size=[480, 640],
+    val_start_frame_interval=1,
+    mode="train",
+    output_fps=16,
+    pad_to_length=49,
+)
+
+my16fps_val_dataset = L(ActionConditionedDataset)(
+    train_annotation_path=os.path.join(my16fps_base_path, "annotation/train"),
+    val_annotation_path=os.path.join(my16fps_base_path, "annotation/val"),
+    test_annotation_path=os.path.join(my16fps_base_path, "annotation/test"),
+    video_path=my16fps_base_path,
+    sequence_interval=1,
+    num_frames=48,
+    cam_ids=[0],
+    accumulate_action=False,
+    video_size=[480, 640],
+    val_start_frame_interval=1,
+    mode="val",
+    output_fps=16,
+    pad_to_length=49,
 )
 
 
@@ -81,6 +117,20 @@ bridge_val_dataloader = L(DataLoader)(
     drop_last=True,
 )
 
+my16fps_train_dataloader = L(DataLoader)(
+    dataset=my16fps_train_dataset,
+    sampler=L(get_sampler)(dataset=my16fps_train_dataset),
+    batch_size=1,
+    drop_last=True,
+)
+
+my16fps_val_dataloader = L(DataLoader)(
+    dataset=my16fps_val_dataset,
+    sampler=L(get_sampler)(dataset=my16fps_val_dataset),
+    batch_size=1,
+    drop_last=True,
+)
+
 
 def register_training_and_val_data_action_conditioned():
     cs = ConfigStore.instance()
@@ -97,4 +147,16 @@ def register_training_and_val_data_action_conditioned():
         package="dataloader_val",
         name="bridge_val",
         node=bridge_val_dataloader,
+    )
+    cs.store(
+        group="dataloader_train",
+        package="dataloader_train",
+        name="my16fps_action_train",
+        node=my16fps_train_dataloader,
+    )
+    cs.store(
+        group="dataloader_val",
+        package="dataloader_val",
+        name="my16fps_action_val",
+        node=my16fps_val_dataloader,
     )

--- a/cosmos_predict2/configs/action_conditioned/defaults/model.py
+++ b/cosmos_predict2/configs/action_conditioned/defaults/model.py
@@ -38,6 +38,23 @@ _PREDICT2_V2W_2B_ACTION_CONDITIONED_FSDP_CONFIG = dict(
     ),
 )
 
+_PREDICT2_V2W_14B_ACTION_CONDITIONED_FSDP_CONFIG = dict(
+    trainer=dict(
+        distributed_parallelism="fsdp",
+    ),
+    model=L(Predict2Video2WorldActionConditionedModel)(
+        config=Predict2Video2WorldModelConfig(
+            pipe_config=get_cosmos_predict2_action_conditioned_pipeline(model_size="14B", resolution="720", fps=16),
+            model_manager_config=L(Predict2ModelManagerConfig)(
+                dit_path=get_cosmos_predict2_action_conditioned_checkpoint(model_size="14B", resolution="720", fps=16),
+                text_encoder_path="",
+            ),
+            fsdp_shard_size=8,
+        ),
+        _recursive_=False,
+    ),
+)
+
 
 def register_model_action_conditioned() -> None:
     cs = ConfigStore.instance()
@@ -47,4 +64,10 @@ def register_model_action_conditioned() -> None:
         package="_global_",
         name="predict2_v2w_2b_action_conditioned_fsdp",
         node=_PREDICT2_V2W_2B_ACTION_CONDITIONED_FSDP_CONFIG,
+    )
+    cs.store(
+        group="model",
+        package="_global_",
+        name="predict2_v2w_14b_action_conditioned_fsdp",
+        node=_PREDICT2_V2W_14B_ACTION_CONDITIONED_FSDP_CONFIG,
     )

--- a/cosmos_predict2/configs/action_conditioned/experiment/exp.py
+++ b/cosmos_predict2/configs/action_conditioned/experiment/exp.py
@@ -45,10 +45,49 @@ predict2_video2world_2b_action_conditioned_training = dict(
     ),
 )
 
+predict2_video2world_14b_action_conditioned_training_my16fps = dict(
+    defaults=[
+        {"override /model": "predict2_v2w_14b_action_conditioned_fsdp"},
+        {"override /optimizer": "fusedadamw"},
+        {"override /ckpt_type": "standard"},
+        {"override /dataloader_train": "my16fps_action_train"},
+        {"override /dataloader_val": "my16fps_action_val"},
+        "_self_",
+    ],
+    model=dict(
+        config=dict(
+            model_manager_config=dict(
+                dit_path="./checkpoints/finetune_cosmos_mv_v2w_14b_multiview_contact_rich_16fps_text_conditioned_train.pt",
+            ),
+            pipe_config=dict(
+                state_t=13,
+                resize_online=False,
+                net=dict(
+                    action_dim=7 * 48,
+                ),
+            ),
+        )
+    ),
+    job=dict(
+        group="action_conditioned",
+        name="predict2_video2world_14b_action_conditioned_my16fps_${now:%Y-%m-%d}_${now:%H-%M-%S}",
+    ),
+    model_parallel=dict(
+        context_parallel_size=8,
+    ),
+    dataloader_train=dict(
+        batch_size=1,
+    ),
+    trainer=dict(
+        distributed_parallelism="fsdp",
+    ),
+)
+
 
 for _item in [
     # predict2_video2world_2b
     predict2_video2world_2b_action_conditioned_training,
+    predict2_video2world_14b_action_conditioned_training_my16fps,
 ]:
     # Get the experiment name from the global variable, e.g. exp01_wan_lora -> experiment_name = "exp01_wan_lora"
     experiment_name = [name.lower() for name, value in globals().items() if value is _item][0]  # noqa: RUF015

--- a/cosmos_predict2/data/action_conditioned/action_conditioned_dataset.py
+++ b/cosmos_predict2/data/action_conditioned/action_conditioned_dataset.py
@@ -62,6 +62,8 @@ class ActionConditionedDataset(Dataset):
         load_t5_embeddings=False,
         load_action=True,
         mode="train",
+        output_fps=4,
+        pad_to_length=None,
     ):
         """Dataset class for loading 3D robot action-conditioned data.
 
@@ -86,6 +88,12 @@ class ActionConditionedDataset(Dataset):
             load_t5_embeddings (bool, optional): Whether to load T5 embeddings. Defaults to False.
             load_action (bool, optional): Whether to load actions. Defaults to True.
             mode (str, optional): Dataset mode - 'train', 'val' or 'test'. Defaults to 'train'.
+            output_fps (int, optional): Frames-per-second metadata stored alongside each
+                sample. Defaults to 4 to match the Bridge dataset recipe.
+            pad_to_length (int | None, optional): If provided, duplicate the final frame and
+                append zero-valued actions until the sequence reaches ``pad_to_length`` frames.
+                This is useful for aligning raw frame counts with tokenizer expectations (e.g.,
+                ensuring 1 + 4k frames for the VAE). Defaults to ``None``.
 
         The dataset loads robot trajectories and computes:
         - RGB video frames from specified camera views
@@ -120,6 +128,8 @@ class ActionConditionedDataset(Dataset):
         self.mode = mode
         self.sequence_length = num_frames
         self.normalize = normalize
+        self.output_fps = output_fps
+        self.pad_to_length = pad_to_length
         self.pre_encode = pre_encode
         self.load_t5_embeddings = load_t5_embeddings
         self.load_action = load_action
@@ -353,7 +363,36 @@ class ActionConditionedDataset(Dataset):
             else:
                 video, cam_id = self._get_obs(label, frame_ids, cam_id, pre_encode=False)
                 video = video.permute(1, 0, 2, 3)  # Rearrange from [T, C, H, W] to [C, T, H, W]
-                data["video"] = video.to(dtype=torch.uint8)
+                video = video.to(dtype=torch.uint8)
+
+                if self.pad_to_length is not None:
+                    current_frames = video.shape[1]
+                    if current_frames > self.pad_to_length:
+                        raise ValueError(
+                            f"Video has {current_frames} frames but pad_to_length={self.pad_to_length}."
+                        )
+                    if current_frames < self.pad_to_length:
+                        pad_frames = self.pad_to_length - current_frames
+                        last_frame = video[:, -1:, :, :]
+                        pad_video = last_frame.repeat(1, pad_frames, 1, 1)
+                        video = torch.cat([video, pad_video], dim=1)
+
+                        if self.load_action:
+                            target_action_steps = self.pad_to_length - 1
+                            current_action_steps = data["action"].shape[0]
+                            if current_action_steps > target_action_steps:
+                                raise ValueError(
+                                    "Padded video length is shorter than existing action sequence."
+                                )
+                            if current_action_steps < target_action_steps:
+                                pad_actions = torch.zeros(
+                                    target_action_steps - current_action_steps,
+                                    data["action"].shape[1],
+                                    dtype=data["action"].dtype,
+                                )
+                                data["action"] = torch.cat([data["action"], pad_actions], dim=0)
+
+                data["video"] = video
 
             data["annotation_file"] = ann_file
 
@@ -372,9 +411,9 @@ class ActionConditionedDataset(Dataset):
                     CosmosTextEncoderConfig.NUM_TOKENS, CosmosTextEncoderConfig.EMBED_DIM, dtype=torch.bfloat16
                 ).cuda()
             data["t5_text_mask"] = torch.ones(CosmosTextEncoderConfig.NUM_TOKENS, dtype=torch.int64).cuda()
-            data["fps"] = 4
+            data["fps"] = self.output_fps
             data["image_size"] = 256 * torch.ones(4).cuda()  # TODO: Does this matter?
-            data["num_frames"] = self.sequence_length
+            data["num_frames"] = data["video"].shape[1]
             data["padding_mask"] = torch.zeros(1, 256, 256).cuda()
 
             return data

--- a/imaginaire/constants.py
+++ b/imaginaire/constants.py
@@ -174,7 +174,7 @@ def get_cosmos_predict2_multiview_checkpoint(
     return f"{model_dir}/model-{resolution}p-{fps}fps-{views}views-{frames}frames.pt"
 
 
-CosmosPredict2ActionConditionedModelSize = Literal["2B"]
+CosmosPredict2ActionConditionedModelSize = Literal["2B", "14B"]
 CosmosPredict2ActionConditionedResolution = Literal["720"]
 CosmosPredict2ActionConditionedFPS = Literal[16]
 


### PR DESCRIPTION
## Summary
- extend the action-conditioned pipeline to cover the 14B video2world architecture and register an accompanying FSDP model preset
- add a 16fps action-conditioned dataset/dataloader preset that pads 48-frame clips to the tokenizer-friendly length and forwards the correct FPS metadata
- introduce a 14B fine-tuning experiment that loads the multiview contact-rich LoRA checkpoint, disables temporal subsampling, and expands the action head for 48 deltas
- augment the dataset implementation with optional FPS overrides and end-padding so downstream configs can realign raw frame counts with tokenizer expectations

## Testing
- `python -m compileall cosmos_predict2 imaginaire`


------
https://chatgpt.com/codex/tasks/task_e_68d2fe501b648324994b78ac488f9ab2