### PR TITLE
Align action-conditioned 14B config to 480p checkpoints

### DIFF
--- a/cosmos_predict2/configs/action_conditioned/config.py
+++ b/cosmos_predict2/configs/action_conditioned/config.py
@@ -110,7 +110,7 @@ _PREDICT2_ACTION_CONDITIONED_PIPELINE_2B = Video2WorldPipelineConfig(
     rectified_flow_t_scaling_factor=1.0,
     rectified_flow_loss_weight_uniform=True,
     resize_online=True,
-    resolution="720",
+    resolution="480",
     ema=L(EMAConfig)(enabled=False),  # defaults to inference
     sigma_conditional=0.0001,
     sigma_data=1.0,
@@ -135,6 +135,100 @@ _PREDICT2_ACTION_CONDITIONED_PIPELINE_2B = Video2WorldPipelineConfig(
     ),
 )
 
+_PREDICT2_ACTION_CONDITIONED_NET_14B = L(ActionConditionedMinimalV1LVGDiT)(
+    max_img_h=240,
+    max_img_w=240,
+    max_frames=128,
+    in_channels=16,
+    out_channels=16,
+    patch_spatial=2,
+    patch_temporal=1,
+    concat_padding_mask=True,
+    model_channels=5120,
+    num_blocks=36,
+    num_heads=40,
+    atten_backend="minimal_a2a",
+    pos_emb_cls="rope3d",
+    pos_emb_learnable=True,
+    pos_emb_interpolation="crop",
+    use_adaln_lora=True,
+    adaln_lora_dim=256,
+    rope_h_extrapolation_ratio=2.0,
+    rope_w_extrapolation_ratio=2.0,
+    rope_t_extrapolation_ratio=0.8333333333333334,
+    extra_per_block_abs_pos_emb=False,
+    rope_enable_fps_modulation=False,
+    sac_config=L(SACConfig)(
+        every_n_blocks=1,
+        mode="predict2_14b_720",
+    ),
+    action_dim=7 * 12,
+)
+
+_PREDICT2_ACTION_CONDITIONED_PIPELINE_14B = Video2WorldPipelineConfig(
+    adjust_video_noise=True,
+    conditioner=L(ActionConditioner)(
+        fps=L(ReMapkey)(
+            dropout_rate=0.0,
+            dtype=None,
+            input_key="fps",
+            output_key="fps",
+        ),
+        padding_mask=L(ReMapkey)(
+            dropout_rate=0.0,
+            dtype=None,
+            input_key="padding_mask",
+            output_key="padding_mask",
+        ),
+        text=L(TextAttr)(
+            dropout_rate=0.2,
+            input_key=["t5_text_embeddings"],
+        ),
+        use_video_condition=L(BooleanFlag)(
+            dropout_rate=0.0,
+            input_key="fps",
+            output_key="use_video_condition",
+        ),
+        action=L(ReMapkey)(
+            input_key="action",
+            output_key="action",
+            dropout_rate=0.0,
+            dtype=None,
+        ),
+    ),
+    conditioning_strategy=str(ConditioningStrategy.FRAME_REPLACE),
+    min_num_conditional_frames=1,
+    max_num_conditional_frames=1,
+    net=_PREDICT2_ACTION_CONDITIONED_NET_14B,
+    precision="bfloat16",
+    rectified_flow_t_scaling_factor=1.0,
+    rectified_flow_loss_weight_uniform=True,
+    resize_online=True,
+    resolution="480",
+    ema=L(EMAConfig)(enabled=False),
+    sigma_conditional=0.0001,
+    sigma_data=1.0,
+    state_ch=16,
+    state_t=16,
+    tokenizer=L(TokenizerInterface)(
+        chunk_duration=81,
+        temporal_window=16,
+        load_mean_std=False,
+        name="tokenizer",
+        vae_pth=get_cosmos_predict2_video2world_tokenizer(model_size="14B"),
+    ),
+    prompt_refiner_config=CosmosReason1Config(
+        checkpoint_dir=COSMOS_REASON1_MODEL_DIR,
+        offload_model_to_cpu=True,
+        enabled=False,
+    ),
+    guardrail_config=CosmosGuardrailConfig(
+        checkpoint_dir=CHECKPOINTS_DIR,
+        offload_model_to_cpu=True,
+        enabled=False,
+    ),
+)
+
 
 @dataclasses.dataclass(frozen=True)
 class _ActionConditionedPipelineConfig:
@@ -143,6 +237,7 @@ class _ActionConditionedPipelineConfig:
 
 _PREDICT2_ACTION_CONDITIONED_PIPELINES: dict[_ActionConditionedPipelineConfig, Video2WorldPipelineConfig] = {
     _ActionConditionedPipelineConfig("2B"): _PREDICT2_ACTION_CONDITIONED_PIPELINE_2B,
+    _ActionConditionedPipelineConfig("14B"): _PREDICT2_ACTION_CONDITIONED_PIPELINE_14B,
 }
 
 

--- a/cosmos_predict2/configs/action_conditioned/defaults/data.py
+++ b/cosmos_predict2/configs/action_conditioned/defaults/data.py
@@ -40,6 +40,7 @@ bridge_train_dataset = L(ActionConditionedDataset)(
     video_size=[480, 640],
     val_start_frame_interval=1,
     mode="train",
+    output_fps=4,
 )
 
 bridge_val_dataset = L(ActionConditionedDataset)(
@@ -54,6 +55,39 @@ bridge_val_dataset = L(ActionConditionedDataset)(
     video_size=[480, 640],
     val_start_frame_interval=1,
     mode="val",
+    output_fps=4,
+)
+
+
+my16fps_base_path = "./datasets/my_16fps_action/"
+my16fps_train_dataset = L(ActionConditionedDataset)(
+    train_annotation_path=os.path.join(my16fps_base_path, "annotation/train"),
+    val_annotation_path=os.path.join(my16fps_base_path, "annotation/val"),
+    test_annotation_path=os.path.join(my16fps_base_path, "annotation/test"),
+    video_path=my16fps_base_path,
+    sequence_interval=1,
+    num_frames=49,
+    cam_ids=[0],
+    accumulate_action=False,
+    video_size=[480, 640],
+    val_start_frame_interval=1,
+    mode="train",
+    output_fps=16,
+)
+
+my16fps_val_dataset = L(ActionConditionedDataset)(
+    train_annotation_path=os.path.join(my16fps_base_path, "annotation/train"),
+    val_annotation_path=os.path.join(my16fps_base_path, "annotation/val"),
+    test_annotation_path=os.path.join(my16fps_base_path, "annotation/test"),
+    video_path=my16fps_base_path,
+    sequence_interval=1,
+    num_frames=49,
+    cam_ids=[0],
+    accumulate_action=False,
+    video_size=[480, 640],
+    val_start_frame_interval=1,
+    mode="val",
+    output_fps=16,
 )
 
 
@@ -81,6 +115,20 @@ bridge_val_dataloader = L(DataLoader)(
     drop_last=True,
 )
 
+my16fps_train_dataloader = L(DataLoader)(
+    dataset=my16fps_train_dataset,
+    sampler=L(get_sampler)(dataset=my16fps_train_dataset),
+    batch_size=1,
+    drop_last=True,
+)
+
+my16fps_val_dataloader = L(DataLoader)(
+    dataset=my16fps_val_dataset,
+    sampler=L(get_sampler)(dataset=my16fps_val_dataset),
+    batch_size=1,
+    drop_last=True,
+)
+
 
 def register_training_and_val_data_action_conditioned():
     cs = ConfigStore.instance()
@@ -97,4 +145,16 @@ def register_training_and_val_data_action_conditioned():
         package="dataloader_val",
         name="bridge_val",
         node=bridge_val_dataloader,
+    )
+    cs.store(
+        group="dataloader_train",
+        package="dataloader_train",
+        name="my16fps_action_train",
+        node=my16fps_train_dataloader,
+    )
+    cs.store(
+        group="dataloader_val",
+        package="dataloader_val",
+        name="my16fps_action_val",
+        node=my16fps_val_dataloader,
     )

--- a/cosmos_predict2/configs/action_conditioned/defaults/model.py
+++ b/cosmos_predict2/configs/action_conditioned/defaults/model.py
@@ -38,6 +38,23 @@ _PREDICT2_V2W_2B_ACTION_CONDITIONED_FSDP_CONFIG = dict(
     ),
 )
 
+_PREDICT2_V2W_14B_ACTION_CONDITIONED_FSDP_CONFIG = dict(
+    trainer=dict(
+        distributed_parallelism="fsdp",
+    ),
+    model=L(Predict2Video2WorldActionConditionedModel)(
+        config=Predict2Video2WorldModelConfig(
+            pipe_config=get_cosmos_predict2_action_conditioned_pipeline(model_size="14B", resolution="480", fps=16),
+            model_manager_config=L(Predict2ModelManagerConfig)(
+                dit_path=get_cosmos_predict2_action_conditioned_checkpoint(model_size="14B", resolution="480", fps=16),
+                text_encoder_path="",
+            ),
+            fsdp_shard_size=8,
+        ),
+        _recursive_=False,
+    ),
+)
+
 
 def register_model_action_conditioned() -> None:
     cs = ConfigStore.instance()
@@ -47,4 +64,10 @@ def register_model_action_conditioned() -> None:
         package="_global_",
         name="predict2_v2w_2b_action_conditioned_fsdp",
         node=_PREDICT2_V2W_2B_ACTION_CONDITIONED_FSDP_CONFIG,
+    )
+    cs.store(
+        group="model",
+        package="_global_",
+        name="predict2_v2w_14b_action_conditioned_fsdp",
+        node=_PREDICT2_V2W_14B_ACTION_CONDITIONED_FSDP_CONFIG,
     )

--- a/cosmos_predict2/configs/action_conditioned/experiment/exp.py
+++ b/cosmos_predict2/configs/action_conditioned/experiment/exp.py
@@ -15,6 +15,13 @@
 
 from hydra.core.config_store import ConfigStore
 
+from cosmos_predict2.configs.action_conditioned.defaults.data import (
+    my16fps_train_dataloader,
+    my16fps_val_dataloader,
+)
+
+# Reuse the LazyCall dataloaders that wrap the 16 fps ActionConditionedDataset preset.
+
 cs = ConfigStore.instance()
 
 """
@@ -45,10 +52,50 @@ predict2_video2world_2b_action_conditioned_training = dict(
     ),
 )
 
+predict2_video2world_14b_action_conditioned_training_my16fps = dict(
+    defaults=[
+        {"override /model": "predict2_v2w_14b_action_conditioned_fsdp"},
+        {"override /optimizer": "fusedadamw"},
+        {"override /ckpt_type": "standard"},
+        "_self_",
+    ],
+    model=dict(
+        config=dict(
+            model_manager_config=dict(
+                dit_path="./checkpoints/finetune_cosmos_mv_v2w_14b_multiview_contact_rich_16fps_text_conditioned_train.pt",
+            ),
+            pipe_config=dict(
+                resolution="480",
+                state_t=13,
+                resize_online=False,
+                net=dict(
+                    action_dim=7 * 48,
+                ),
+                tokenizer=dict(
+                    temporal_window=13,
+                ),
+            ),
+        )
+    ),
+    job=dict(
+        group="action_conditioned",
+        name="predict2_video2world_14b_action_conditioned_my16fps_${now:%Y-%m-%d}_${now:%H-%M-%S}",
+    ),
+    model_parallel=dict(
+        context_parallel_size=8,
+    ),
+    dataloader_train=my16fps_train_dataloader,
+    dataloader_val=my16fps_val_dataloader,
+    trainer=dict(
+        distributed_parallelism="fsdp",
+    ),
+)
+
 
 for _item in [
     # predict2_video2world_2b
     predict2_video2world_2b_action_conditioned_training,
+    predict2_video2world_14b_action_conditioned_training_my16fps,
 ]:
     # Get the experiment name from the global variable, e.g. exp01_wan_lora -> experiment_name = "exp01_wan_lora"
     experiment_name = [name.lower() for name, value in globals().items() if value is _item][0]  # noqa: RUF015

--- a/cosmos_predict2/data/action_conditioned/action_conditioned_dataset.py
+++ b/cosmos_predict2/data/action_conditioned/action_conditioned_dataset.py
@@ -62,6 +62,7 @@ class ActionConditionedDataset(Dataset):
         load_t5_embeddings=False,
         load_action=True,
         mode="train",
+        output_fps=4,
     ):
         """Dataset class for loading 3D robot action-conditioned data.
 
@@ -86,6 +87,8 @@ class ActionConditionedDataset(Dataset):
             load_t5_embeddings (bool, optional): Whether to load T5 embeddings. Defaults to False.
             load_action (bool, optional): Whether to load actions. Defaults to True.
             mode (str, optional): Dataset mode - 'train', 'val' or 'test'. Defaults to 'train'.
+            output_fps (int, optional): Frames-per-second metadata stored alongside each
+                sample. Defaults to 4 to match the Bridge dataset recipe.
 
         The dataset loads robot trajectories and computes:
         - RGB video frames from specified camera views
@@ -120,6 +123,7 @@ class ActionConditionedDataset(Dataset):
         self.mode = mode
         self.sequence_length = num_frames
         self.normalize = normalize
+        self.output_fps = output_fps
         self.pre_encode = pre_encode
         self.load_t5_embeddings = load_t5_embeddings
         self.load_action = load_action
@@ -353,7 +357,9 @@ class ActionConditionedDataset(Dataset):
             else:
                 video, cam_id = self._get_obs(label, frame_ids, cam_id, pre_encode=False)
                 video = video.permute(1, 0, 2, 3)  # Rearrange from [T, C, H, W] to [C, T, H, W]
-                data["video"] = video.to(dtype=torch.uint8)
+                video = video.to(dtype=torch.uint8)
+
+                data["video"] = video
 
             data["annotation_file"] = ann_file
 
@@ -372,9 +378,9 @@ class ActionConditionedDataset(Dataset):
                     CosmosTextEncoderConfig.NUM_TOKENS, CosmosTextEncoderConfig.EMBED_DIM, dtype=torch.bfloat16
                 ).cuda()
             data["t5_text_mask"] = torch.ones(CosmosTextEncoderConfig.NUM_TOKENS, dtype=torch.int64).cuda()
-            data["fps"] = 4
+            data["fps"] = self.output_fps
             data["image_size"] = 256 * torch.ones(4).cuda()  # TODO: Does this matter?
-            data["num_frames"] = self.sequence_length
+            data["num_frames"] = data["video"].shape[1]
             data["padding_mask"] = torch.zeros(1, 256, 256).cuda()
 
             return data

--- a/imaginaire/constants.py
+++ b/imaginaire/constants.py
@@ -174,8 +174,8 @@ def get_cosmos_predict2_multiview_checkpoint(
     return f"{model_dir}/model-{resolution}p-{fps}fps-{views}views-{frames}frames.pt"
 
 
-CosmosPredict2ActionConditionedModelSize = Literal["2B"]
-CosmosPredict2ActionConditionedResolution = Literal["720"]
+CosmosPredict2ActionConditionedModelSize = Literal["2B", "14B"]
+CosmosPredict2ActionConditionedResolution = Literal["480", "720"]
 CosmosPredict2ActionConditionedFPS = Literal[16]
 
 


### PR DESCRIPTION
## Summary
- allow action-conditioned configs to declare either 480p or 720p resolutions
- default the 2B and 14B action-conditioned pipelines to 480p and request the 480p checkpoint in the 14B model preset
- ensure the 16fps fine-tuning experiment explicitly keeps the 480p layout when loading the multiview video2world LoRA checkpoint
- drop the dataset padding hook now that the 16fps recipe emits 49-frame windows and align the experiment tokenizer window with the 48-action target

## Testing
- `python -m compileall cosmos_predict2 imaginaire`


------
https://chatgpt.com/codex/tasks/task_e_68d2fe501b648324994b78ac488f9ab2