### PR TITLE
Instantiate Video2World EMA under meta context

### DIFF
--- a/cosmos_predict2/models/video2world_action_dit.py
+++ b/cosmos_predict2/models/video2world_action_dit.py
@@ -33,6 +33,12 @@ class Mlp(nn.Module):
         self.fc2 = nn.Linear(hidden_features, out_features)
         self.drop = nn.Dropout(drop)
 
+    def reset_parameters(self) -> None:
+        self.fc1.reset_parameters()
+        self.fc2.reset_parameters()
+        if hasattr(self.activation, "reset_parameters"):
+            self.activation.reset_parameters()
+
     def forward(self, x):
         x = self.fc1(x)
         x = self.activation(x)


### PR DESCRIPTION
## Summary
- add a helper that materializes meta tensors so checkpoints can backfill weights without running full initializers
- instantiate the Video2World EMA DiT under the meta-device context and materialize it before copying weights

## Testing
- python -m compileall cosmos_predict2/pipelines/video2world.py

------
https://chatgpt.com/codex/tasks/task_e_68d8b8be0714832492919eaa79a38101