### PR TITLE
Align video2world LoRA loading with example flow

### DIFF
--- a/cosmos_predict2/models/video2world_action_model.py
+++ b/cosmos_predict2/models/video2world_action_model.py
@@ -14,12 +14,12 @@
 # limitations under the License.
 
 import math
+from typing import Any
 
 import torch
 from megatron.core import parallel_state
 from torch.distributed.device_mesh import init_device_mesh
 
-from cosmos_predict2.models.utils import load_state_dict
 from cosmos_predict2.models.video2world_model import Predict2Video2WorldModel, Predict2Video2WorldModelConfig
 from cosmos_predict2.pipelines.video2world_action import Video2WorldActionConditionedPipeline
 from cosmos_predict2.utils.optim_instantiate import get_base_scheduler
@@ -65,11 +65,12 @@ class Predict2Video2WorldActionConditionedModel(Predict2Video2WorldModel):
         self.pipe = Video2WorldActionConditionedPipeline.from_config(
             config.pipe_config,
             dit_path=config.model_manager_config.dit_path,
+            load_weights=False,
         )
 
         self.freeze_parameters()
         self._enable_action_heads_training()
-        lora_reloaded_from_checkpoint = False
+        checkpoint_report: dict[str, Any] | None = None
         if config.train_architecture == "lora":
             self.add_lora_to_model(
                 self.pipe.dit,
@@ -86,11 +87,21 @@ class Predict2Video2WorldActionConditionedModel(Predict2Video2WorldModel):
                     lora_target_modules=config.lora_target_modules,
                     init_lora_weights=config.init_lora_weights,
                 )
-            lora_reloaded_from_checkpoint = self._maybe_reload_lora_from_checkpoint()
+            checkpoint_report = self.pipe.load_checkpoint(
+                config.model_manager_config.dit_path
+            )
+            self._log_lora_statistics()
+            log.info(
+                "LoRA weights restored from checkpoint: %s",
+                bool(checkpoint_report and checkpoint_report.get("contains_lora")),
+            )
             self._enable_action_heads_training()
         else:
+            checkpoint_report = self.pipe.load_checkpoint(
+                config.model_manager_config.dit_path
+            )
             self.pipe.denoising_model().requires_grad_(True)
-        self._log_training_architecture_summary(lora_reloaded_from_checkpoint)
+        self._log_training_architecture_summary(checkpoint_report)
         total_params = sum(p.numel() for p in self.parameters())
         frozen_params = sum(p.numel() for p in self.parameters() if not p.requires_grad)
         trainable_params = sum(p.numel() for p in self.parameters() if p.requires_grad)
@@ -177,55 +188,7 @@ class Predict2Video2WorldActionConditionedModel(Predict2Video2WorldModel):
             f"| params={action_param_count}"
         )
 
-    def _maybe_reload_lora_from_checkpoint(self) -> bool:
-        dit_path = getattr(self.config.model_manager_config, "dit_path", "")
-        if not dit_path:
-            log.info("No DiT checkpoint path provided; skipping LoRA reload.")
-            return False
-
-        state_dict = load_state_dict(dit_path)
-        lora_keys = [key for key in state_dict if "lora_" in key]
-        if not lora_keys:
-            log.info("Checkpoint does not contain LoRA parameters; skipping LoRA reload.")
-            return False
-
-        def load_into_module(module: torch.nn.Module | None, prefix: str) -> bool:
-            if module is None:
-                return False
-            filtered_state = {}
-            for key, value in state_dict.items():
-                if "lora_" not in key:
-                    continue
-                if key.startswith(prefix):
-                    filtered_state[key[len(prefix) :]] = value
-                elif key.startswith(prefix + "module."):
-                    filtered_state[key[len(prefix) + len("module.") :]] = value
-            if not filtered_state:
-                return False
-            missing, unexpected = module.load_state_dict(filtered_state, strict=False, assign=True)
-            if missing:
-                log.debug(f"Missing keys when loading LoRA params ({prefix}): {missing}")
-            if unexpected:
-                log.debug(f"Unexpected keys when loading LoRA params ({prefix}): {unexpected}")
-            return True
-
-        loaded_regular = load_into_module(self.pipe.dit, "net.")
-        loaded_ema = load_into_module(self.pipe.dit_ema, "net_ema.")
-
-        del state_dict
-
-        if loaded_regular or loaded_ema:
-            log.success(
-                f"Restored LoRA parameters from checkpoint (regular={loaded_regular}, ema={loaded_ema})"
-            )
-            return True
-
-        log.warning(
-            "LoRA parameters were present in checkpoint but did not match any modules; they may use an unsupported prefix."
-        )
-        return False
-
-    def _log_training_architecture_summary(self, lora_reloaded_from_checkpoint: bool) -> None:
+    def _log_training_architecture_summary(self, checkpoint_report: dict[str, Any] | None) -> None:
         action_trainable = {
             module_name: any(param.requires_grad for param in getattr(self.pipe.dit, module_name).parameters())
             for module_name in ("action_embedder_B_D", "action_embedder_B_3D")
@@ -246,7 +209,8 @@ class Predict2Video2WorldActionConditionedModel(Predict2Video2WorldModel):
                 f"| targets: {self.config.lora_target_modules}"
             )
             log.info(
-                f"  LoRA weights restored from checkpoint: {lora_reloaded_from_checkpoint}"
+                "  LoRA weights restored from checkpoint: %s",
+                bool(checkpoint_report and checkpoint_report.get("contains_lora")),
             )
 
         trainable_params = sum(p.numel() for p in self.parameters() if p.requires_grad)

--- a/cosmos_predict2/models/video2world_model.py
+++ b/cosmos_predict2/models/video2world_model.py
@@ -32,7 +32,6 @@ from cosmos_predict2.configs.base.config_video2world import (
     get_cosmos_predict2_video2world_pipeline,
 )
 from cosmos_predict2.networks.model_weights_stats import WeightTrainingStat
-from cosmos_predict2.models.utils import load_state_dict
 from cosmos_predict2.pipelines.video2world import Video2WorldPipeline
 from cosmos_predict2.utils.checkpointer import non_strict_load_model
 from cosmos_predict2.utils.optim_instantiate import get_base_scheduler
@@ -140,10 +139,11 @@ class Predict2Video2WorldModel(ImaginaireModel):
         self.pipe = Video2WorldPipeline.from_config(
             config.pipe_config,
             dit_path=config.model_manager_config.dit_path,
+            load_weights=False,
         )
 
         self.freeze_parameters()
-        lora_reloaded_from_checkpoint = False
+        checkpoint_report: dict[str, Any] | None = None
         if config.train_architecture == "lora":
             self.add_lora_to_model(
                 self.pipe.dit,
@@ -160,14 +160,19 @@ class Predict2Video2WorldModel(ImaginaireModel):
                     lora_target_modules=config.lora_target_modules,
                     init_lora_weights=config.init_lora_weights,
                 )
-            lora_reloaded_from_checkpoint = self._maybe_reload_lora_from_checkpoint()
+            checkpoint_report = self.pipe.load_checkpoint(
+                config.model_manager_config.dit_path
+            )
             # Enhanced LoRA logging
             self._log_lora_statistics()
             log.info(
                 "LoRA weights restored from checkpoint: %s",
-                lora_reloaded_from_checkpoint,
+                bool(checkpoint_report and checkpoint_report.get("contains_lora")),
             )
         else:
+            checkpoint_report = self.pipe.load_checkpoint(
+                config.model_manager_config.dit_path
+            )
             self.pipe.denoising_model().requires_grad_(True)
         total_params = sum(p.numel() for p in self.parameters())
         frozen_params = sum(p.numel() for p in self.parameters() if not p.requires_grad)
@@ -357,54 +362,6 @@ class Predict2Video2WorldModel(ImaginaireModel):
             log.info(f"  Total LoRA: {total_lora_params:,} parameters")
         else:
             log.warning("No LoRA parameters found in model")
-
-    def _maybe_reload_lora_from_checkpoint(self) -> bool:
-        dit_path = getattr(self.config.model_manager_config, "dit_path", "")
-        if not dit_path:
-            log.info("No DiT checkpoint path provided; skipping LoRA reload.")
-            return False
-
-        state_dict = load_state_dict(dit_path)
-        lora_keys = [key for key in state_dict if "lora_" in key]
-        if not lora_keys:
-            log.info("Checkpoint does not contain LoRA parameters; skipping LoRA reload.")
-            return False
-
-        def load_into_module(module: torch.nn.Module | None, prefix: str) -> bool:
-            if module is None:
-                return False
-            filtered_state: dict[str, Any] = {}
-            for key, value in state_dict.items():
-                if "lora_" not in key:
-                    continue
-                if key.startswith(prefix):
-                    filtered_state[key[len(prefix) :]] = value
-                elif key.startswith(prefix + "module."):
-                    filtered_state[key[len(prefix) + len("module.") :]] = value
-            if not filtered_state:
-                return False
-            missing, unexpected = module.load_state_dict(filtered_state, strict=False, assign=True)
-            if missing:
-                log.debug(f"Missing keys when loading LoRA params ({prefix}): {missing}")
-            if unexpected:
-                log.debug(f"Unexpected keys when loading LoRA params ({prefix}): {unexpected}")
-            return True
-
-        loaded_regular = load_into_module(self.pipe.dit, "net.")
-        loaded_ema = load_into_module(self.pipe.dit_ema, "net_ema.")
-
-        del state_dict
-
-        if loaded_regular or loaded_ema:
-            log.success(
-                f"Restored LoRA parameters from checkpoint (regular={loaded_regular}, ema={loaded_ema})"
-            )
-            return True
-
-        log.warning(
-            "LoRA parameters were present in checkpoint but did not match any modules; they may use an unsupported prefix."
-        )
-        return False
 
     def setup_data_key(self) -> None:
         self.input_video_key = self.config.input_video_key  # by default it is video key for Video diffusion model


### PR DESCRIPTION
## Summary
- add an explicit `load_checkpoint` helper and optional `load_weights` flag to the video2world pipelines so checkpoints are loaded after any injected adapters, mirroring the example scripts
- update the video2world model initializers to inject LoRA before loading weights, reuse the new pipeline loader, and drop the bespoke LoRA-only reload path
- apply the same flow to the action-conditioned pipeline and model, keeping their additional logging and action-head handling intact

## Testing
- `ruff check cosmos_predict2/models/video2world_model.py cosmos_predict2/models/video2world_action_model.py cosmos_predict2/pipelines/video2world.py cosmos_predict2/pipelines/video2world_action.py`


------
https://chatgpt.com/codex/tasks/task_e_68d9e52f248c83248dfa6f69e148d919